### PR TITLE
#9 #10 feat(graphql): implement token-based login flow and current user query

### DIFF
--- a/TaskManager/config/graphql/types/Mutation.types.yaml
+++ b/TaskManager/config/graphql/types/Mutation.types.yaml
@@ -6,6 +6,13 @@ MutationType:
                 type: "ImportUsersPayload!"
                 resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Mutation\\\\User\\\\ImportUsersMutation').__invoke()"
 
+            loginUser:
+                type: "LoginPayload!"
+                args:
+                    username:
+                        type: "String!"
+                resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Mutation\\\\User\\\\LoginUserMutation').__invoke(args)"
+
             promoteUserToAdmin:
                 type: "UserType!"
                 args:

--- a/TaskManager/config/graphql/types/Query.types.yaml
+++ b/TaskManager/config/graphql/types/Query.types.yaml
@@ -5,21 +5,22 @@ QueryType:
             users:
                 type: "[UserType]"
                 resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Resolver\\\\UserResolver').resolveAll()"
+
             me:
                 type: "UserType"
-                args:
-                    username:
-                        type: "String!"
-                resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Resolver\\\\UserResolver').resolveMe(args)"
+                resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Query\\\\User\\\\MeQuery').__invoke()"
+
             tasks:
                 type: "[TaskType]"
                 resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Resolver\\\\TaskResolver').resolveAll()"
+
             myTasks:
                 type: "[TaskType]"
                 args:
                     userId:
                         type: "String!"
                 resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Resolver\\\\TaskResolver').resolveByUser(args)"
+
             importedUsers:
                 type: "[UserType!]!"
                 resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Query\\\\User\\\\ImportedUsersQuery').__invoke()"

--- a/TaskManager/config/graphql/types/User.types.yaml
+++ b/TaskManager/config/graphql/types/User.types.yaml
@@ -23,3 +23,12 @@ ImportUsersPayload:
                 type: "Int!"
             users:
                 type: "[UserType!]!"
+
+LoginPayload:
+    type: object
+    config:
+        fields:
+            token:
+                type: "String!"
+            user:
+                type: "UserType!"

--- a/TaskManager/config/services.yaml
+++ b/TaskManager/config/services.yaml
@@ -44,3 +44,17 @@ services:
         public: true
         autowire: true
         autoconfigure: true
+
+    App\Infrastructure\GraphQL\Mutation\User\LoginUserMutation:
+        public: true
+        autowire: true
+        autoconfigure: true
+
+    App\Infrastructure\GraphQL\Query\User\MeQuery:
+        public: true
+        autowire: true
+        autoconfigure: true
+
+    App\Infrastructure\Security\TokenService:
+        arguments:
+            $appSecret: '%kernel.secret%'

--- a/TaskManager/src/Infrastructure/GraphQL/Mutation/User/LoginUserMutation.php
+++ b/TaskManager/src/Infrastructure/GraphQL/Mutation/User/LoginUserMutation.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\GraphQL\Mutation\User;
+
+use App\Application\User\UseCase\LoginUserUseCase;
+use App\Infrastructure\Security\TokenService;
+use Overblog\GraphQLBundle\Definition\Argument;
+
+final class LoginUserMutation
+{
+    public function __construct(
+        private readonly LoginUserUseCase $useCase,
+        private readonly TokenService $tokenService,
+    ) {
+    }
+
+    public function __invoke(Argument $args): array
+    {
+        $user = $this->useCase->execute($args['username']);
+        $token = $this->tokenService->createToken($user->getId()->getValue());
+
+        return [
+            'token' => $token,
+            'user' => $user,
+        ];
+    }
+}

--- a/TaskManager/src/Infrastructure/GraphQL/Query/User/MeQuery.php
+++ b/TaskManager/src/Infrastructure/GraphQL/Query/User/MeQuery.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\GraphQL\Query\User;
+
+use App\Domain\User\Repository\UserRepositoryInterface;
+use App\Domain\User\ValueObject\UserId;
+use App\Infrastructure\Security\TokenService;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class MeQuery
+{
+    public function __construct(
+        private readonly UserRepositoryInterface $userRepository,
+        private readonly RequestStack $requestStack,
+        private readonly TokenService $tokenService,
+    ) {
+    }
+
+    public function __invoke(): ?object
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if ($request === null) {
+            return null;
+        }
+
+        $authorization = $request->headers->get('Authorization');
+
+        if (!$authorization || !str_starts_with($authorization, 'Bearer ')) {
+            return null;
+        }
+
+        $token = substr($authorization, 7);
+        $userId = $this->tokenService->extractUserId($token);
+
+        if ($userId === null) {
+            return null;
+        }
+
+        return $this->userRepository->findById(UserId::fromString($userId));
+    }
+}

--- a/TaskManager/src/Infrastructure/Security/TokenService.php
+++ b/TaskManager/src/Infrastructure/Security/TokenService.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Security;
+
+final class TokenService
+{
+    public function __construct(
+        private readonly string $appSecret,
+    ) {
+    }
+
+    public function createToken(string $userId): string
+    {
+        $payload = base64_encode(json_encode([
+            'userId' => $userId,
+            'iat' => time(),
+        ], JSON_THROW_ON_ERROR));
+
+        $signature = hash_hmac('sha256', $payload, $this->appSecret);
+
+        return $payload.'.'.$signature;
+    }
+
+    public function extractUserId(string $token): ?string
+    {
+        $parts = explode('.', $token, 2);
+
+        if (count($parts) !== 2) {
+            return null;
+        }
+
+        [$payload, $signature] = $parts;
+
+        $expectedSignature = hash_hmac('sha256', $payload, $this->appSecret);
+
+        if (!hash_equals($expectedSignature, $signature)) {
+            return null;
+        }
+
+        $decoded = json_decode(base64_decode($payload, true) ?: '', true);
+
+        if (!is_array($decoded) || !isset($decoded['userId'])) {
+            return null;
+        }
+
+        return (string) $decoded['userId'];
+    }
+}


### PR DESCRIPTION
Add token-based user login mutation without session usage. Add GraphQL me query that resolves current user from bearer token. Update GraphQL types and service wiring for login payload and auth token handling.

Closes #9
Closes #10