### PR TITLE
feat(tasks): implement task workflow GraphQL operations and authorization facade

### DIFF
--- a/TaskManager/composer.json
+++ b/TaskManager/composer.json
@@ -39,6 +39,7 @@
         "symfony/string": "7.4.*",
         "symfony/translation": "7.4.*",
         "symfony/twig-bundle": "7.4.*",
+        "symfony/uid": "7.4.*",
         "symfony/ux-turbo": "^2.32",
         "symfony/validator": "7.4.*",
         "symfony/web-link": "7.4.*",

--- a/TaskManager/composer.lock
+++ b/TaskManager/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "589da15323cb86708aed42745d8b293a",
+    "content-hash": "dd75f00a3a5b3a0182c7ff0127b5373c",
     "packages": [
         {
             "name": "composer/semver",
@@ -5631,6 +5631,89 @@
             "time": "2025-06-23T16:12:55+00:00"
         },
         {
+            "name": "symfony/polyfill-uuid",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-uuid.git",
+                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-uuid": "*"
+            },
+            "suggest": {
+                "ext-uuid": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Uuid\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for uuid functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "uuid"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
             "name": "symfony/process",
             "version": "v7.4.5",
             "source": {
@@ -7293,6 +7376,84 @@
                 }
             ],
             "time": "2026-03-04T12:49:16+00:00"
+        },
+        {
+            "name": "symfony/uid",
+            "version": "v7.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/uid.git",
+                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/7719ce8aba76be93dfe249192f1fbfa52c588e36",
+                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-uuid": "^1.15"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Uid\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to generate and represent UIDs",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "UID",
+                "ulid",
+                "uuid"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/uid/tree/v7.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-03T23:30:35+00:00"
         },
         {
             "name": "symfony/ux-turbo",

--- a/TaskManager/config/graphql/types/Mutation.types.yaml
+++ b/TaskManager/config/graphql/types/Mutation.types.yaml
@@ -21,7 +21,7 @@ MutationType:
                 resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Mutation\\\\User\\\\PromoteUserToAdminMutation').__invoke(args)"
 
             createTask:
-                type: "TaskType"
+                type: "TaskType!"
                 args:
                     title:
                         type: "String!"
@@ -29,13 +29,13 @@ MutationType:
                         type: "String!"
                     assignedUserId:
                         type: "String!"
-                resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Resolver\\\\TaskResolver').resolveCreate(args)"
+                resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Mutation\\\\Task\\\\CreateTaskMutation').__invoke(args)"
 
             updateTaskStatus:
-                type: "TaskType"
+                type: "TaskType!"
                 args:
                     taskId:
                         type: "String!"
                     status:
                         type: "String!"
-                resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Resolver\\\\TaskResolver').resolveUpdateStatus(args)"
+                resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Mutation\\\\Task\\\\UpdateTaskStatusMutation').__invoke(args)"

--- a/TaskManager/config/graphql/types/Query.types.yaml
+++ b/TaskManager/config/graphql/types/Query.types.yaml
@@ -11,15 +11,19 @@ QueryType:
                 resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Query\\\\User\\\\MeQuery').__invoke()"
 
             tasks:
-                type: "[TaskType]"
-                resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Resolver\\\\TaskResolver').resolveAll()"
+                type: "[TaskType!]!"
+                resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Query\\\\Task\\\\AllTasksQuery').__invoke()"
 
             myTasks:
-                type: "[TaskType]"
+                type: "[TaskType!]!"
+                resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Query\\\\Task\\\\MyTasksQuery').__invoke()"
+
+            taskHistory:
+                type: "[TaskHistoryItemType!]!"
                 args:
-                    userId:
+                    taskId:
                         type: "String!"
-                resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Resolver\\\\TaskResolver').resolveByUser(args)"
+                resolve: "@=service('App\\\\Infrastructure\\\\GraphQL\\\\Query\\\\Task\\\\TaskHistoryQuery').__invoke(args)"
 
             importedUsers:
                 type: "[UserType!]!"

--- a/TaskManager/config/graphql/types/Task.types.yaml
+++ b/TaskManager/config/graphql/types/Task.types.yaml
@@ -14,3 +14,18 @@ TaskType:
                 type: "String!"
             createdAt:
                 type: "String!"
+                resolve: "@=value.getCreatedAt().format('c')"
+            updatedAt:
+                type: "String!"
+                resolve: "@=value.getUpdatedAt().format('c')"
+
+TaskHistoryItemType:
+    type: object
+    config:
+        fields:
+            eventType:
+                type: "String!"
+            payload:
+                type: "String!"
+            occurredAt:
+                type: "String!"

--- a/TaskManager/config/reference.php
+++ b/TaskManager/config/reference.php
@@ -645,7 +645,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         }>,
  *     },
  *     uid?: bool|array{ // Uid configuration
- *         enabled?: bool|Param, // Default: false
+ *         enabled?: bool|Param, // Default: true
  *         default_uuid_version?: 7|6|4|1|Param, // Default: 7
  *         name_based_uuid_version?: 5|3|Param, // Default: 5
  *         name_based_uuid_namespace?: scalar|Param|null,

--- a/TaskManager/config/services.yaml
+++ b/TaskManager/config/services.yaml
@@ -58,3 +58,47 @@ services:
     App\Infrastructure\Security\TokenService:
         arguments:
             $appSecret: '%kernel.secret%'
+
+    App\Infrastructure\Security\AuthorizationService:
+        autowire: true
+        autoconfigure: true
+
+    App\Application\Task\UseCase\CreateTaskUseCase:
+        public: true
+        autowire: true
+        autoconfigure: true
+
+    App\Application\Task\UseCase\UpdateTaskStatusUseCase:
+        public: true
+        autowire: true
+        autoconfigure: true
+
+    App\Application\Task\UseCase\GetTaskHistoryUseCase:
+        public: true
+        autowire: true
+        autoconfigure: true
+
+    App\Infrastructure\GraphQL\Mutation\Task\CreateTaskMutation:
+        public: true
+        autowire: true
+        autoconfigure: true
+
+    App\Infrastructure\GraphQL\Mutation\Task\UpdateTaskStatusMutation:
+        public: true
+        autowire: true
+        autoconfigure: true
+
+    App\Infrastructure\GraphQL\Query\Task\AllTasksQuery:
+        public: true
+        autowire: true
+        autoconfigure: true
+
+    App\Infrastructure\GraphQL\Query\Task\MyTasksQuery:
+        public: true
+        autowire: true
+        autoconfigure: true
+
+    App\Infrastructure\GraphQL\Query\Task\TaskHistoryQuery:
+        public: true
+        autowire: true
+        autoconfigure: true

--- a/TaskManager/src/Application/Task/DTO/TaskHistoryItem.php
+++ b/TaskManager/src/Application/Task/DTO/TaskHistoryItem.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Task\DTO;
+
+final class TaskHistoryItem
+{
+    public function __construct(
+        public readonly string $eventType,
+        public readonly string $payload,
+        public readonly string $occurredAt,
+    ) {
+    }
+}

--- a/TaskManager/src/Application/Task/Strategy/TaskStatusContext.php
+++ b/TaskManager/src/Application/Task/Strategy/TaskStatusContext.php
@@ -11,16 +11,16 @@ use DomainException;
 
 final class TaskStatusContext
 {
-    /** @param TaskStatusStrategyInterface[] $strategies */
-    public function __construct(private readonly array $strategies) {}
+    /** @param iterable<TaskStatusStrategyInterface> $strategies */
+    public function __construct(private readonly iterable $strategies) {}
 
     public function transition(Task $task, TaskStatus $targetStatus): void
     {
         foreach ($this->strategies as $strategy) {
             if ($strategy->supports($task->getStatus())) {
-                // Only apply if the strategy leads to the desired target
                 $clone = clone $task;
                 $strategy->apply($clone);
+
                 if ($clone->getStatus()->equals($targetStatus)) {
                     $strategy->apply($task);
                     return;

--- a/TaskManager/src/Application/Task/UseCase/CreateTaskUseCase.php
+++ b/TaskManager/src/Application/Task/UseCase/CreateTaskUseCase.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Task\UseCase;
+
+use App\Application\Task\DTO\CreateTaskInput;
+use App\Application\Task\Factory\TaskFactory;
+use App\Domain\Task\Entity\Task;
+use App\Domain\Task\Repository\TaskRepositoryInterface;
+use App\Infrastructure\Security\AuthorizationService;
+
+final class CreateTaskUseCase
+{
+    public function __construct(
+        private readonly TaskFactory $taskFactory,
+        private readonly TaskRepositoryInterface $taskRepository,
+        private readonly AuthorizationService $authorizationService,
+    ) {
+    }
+
+    public function execute(CreateTaskInput $input): Task
+    {
+        $this->authorizationService->requireAdmin();
+
+        $task = $this->taskFactory->create(
+            title: $input->title,
+            description: $input->description,
+            assignedUserId: $input->assignedUserId,
+        );
+
+        $this->taskRepository->save($task);
+
+        return $task;
+    }
+}

--- a/TaskManager/src/Application/Task/UseCase/GetTaskHistoryUseCase.php
+++ b/TaskManager/src/Application/Task/UseCase/GetTaskHistoryUseCase.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Task\UseCase;
+
+use App\Application\Task\DTO\TaskHistoryItem;
+use App\Infrastructure\Persistence\Doctrine\EventStore\EventStoreRepository;
+use App\Infrastructure\Security\AuthorizationService;
+
+final class GetTaskHistoryUseCase
+{
+    public function __construct(
+        private readonly EventStoreRepository $eventStoreRepository,
+        private readonly AuthorizationService $authorizationService,
+    ) {
+    }
+
+    /** @return TaskHistoryItem[] */
+    public function execute(string $taskId): array
+    {
+        $this->authorizationService->requireCurrentUser();
+
+        $events = $this->eventStoreRepository->findByAggregateId($taskId);
+
+        return array_map(
+            static fn($event) => new TaskHistoryItem(
+                eventType: $event->getEventType(),
+                payload: json_encode($event->getPayload(), JSON_THROW_ON_ERROR),
+                occurredAt: $event->getOccurredAt()->format(DATE_ATOM),
+            ),
+            $events
+        );
+    }
+}

--- a/TaskManager/src/Application/Task/UseCase/UpdateTaskStatusUseCase.php
+++ b/TaskManager/src/Application/Task/UseCase/UpdateTaskStatusUseCase.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Task\UseCase;
+
+use App\Application\Task\Strategy\TaskStatusContext;
+use App\Domain\Task\Entity\Task;
+use App\Domain\Task\Repository\TaskRepositoryInterface;
+use App\Domain\Task\ValueObject\TaskId;
+use App\Domain\Task\ValueObject\TaskStatus;
+use App\Infrastructure\Security\AuthorizationService;
+use RuntimeException;
+
+final class UpdateTaskStatusUseCase
+{
+    public function __construct(
+        private readonly TaskRepositoryInterface $taskRepository,
+        private readonly TaskStatusContext $taskStatusContext,
+        private readonly AuthorizationService $authorizationService,
+    ) {
+    }
+
+    public function execute(string $taskId, string $targetStatus): Task
+    {
+        $task = $this->taskRepository->findById(TaskId::fromString($taskId));
+
+        if ($task === null) {
+            throw new RuntimeException(sprintf('Task "%s" not found.', $taskId));
+        }
+
+        if (!$this->authorizationService->canManageTaskAssignedTo($task->getAssignedUserId()->getValue())) {
+            throw new RuntimeException('Forbidden.');
+        }
+
+        $this->taskStatusContext->transition($task, TaskStatus::fromString($targetStatus));
+        $this->taskRepository->save($task);
+
+        return $task;
+    }
+}

--- a/TaskManager/src/Domain/Task/Event/TaskCreatedEvent.php
+++ b/TaskManager/src/Domain/Task/Event/TaskCreatedEvent.php
@@ -9,10 +9,11 @@ use DateTimeImmutable;
 final class TaskCreatedEvent
 {
     public function __construct(
-        public readonly string            $taskId,
-        public readonly string            $title,
-        public readonly string            $status,
-        public readonly string            $assignedUserId,
+        public readonly string $taskId,
+        public readonly string $title,
+        public readonly string $status,
+        public readonly string $assignedUserId,
         public readonly DateTimeImmutable $occurredAt,
-    ) {}
+    ) {
+    }
 }

--- a/TaskManager/src/Domain/Task/Event/TaskStatusUpdatedEvent.php
+++ b/TaskManager/src/Domain/Task/Event/TaskStatusUpdatedEvent.php
@@ -9,9 +9,10 @@ use DateTimeImmutable;
 final class TaskStatusUpdatedEvent
 {
     public function __construct(
-        public readonly string            $taskId,
-        public readonly string            $previousStatus,
-        public readonly string            $newStatus,
+        public readonly string $taskId,
+        public readonly string $previousStatus,
+        public readonly string $newStatus,
         public readonly DateTimeImmutable $occurredAt,
-    ) {}
+    ) {
+    }
 }

--- a/TaskManager/src/Domain/Task/ValueObject/TaskId.php
+++ b/TaskManager/src/Domain/Task/ValueObject/TaskId.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Domain\Task\ValueObject;
 
 use InvalidArgumentException;
-use Ramsey\Uuid\Uuid;
+use Symfony\Component\Uid\Uuid;
 
 final class TaskId
 {
@@ -13,15 +13,16 @@ final class TaskId
 
     private function __construct(string $value)
     {
-        if (empty($value)) {
+        if ($value === '') {
             throw new InvalidArgumentException('TaskId cannot be empty.');
         }
+
         $this->value = $value;
     }
 
     public static function generate(): self
     {
-        return new self(Uuid::uuid4()->toString());
+        return new self(Uuid::v7()->toRfc4122());
     }
 
     public static function fromString(string $value): self

--- a/TaskManager/src/Domain/User/ValueObject/UserId.php
+++ b/TaskManager/src/Domain/User/ValueObject/UserId.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Domain\User\ValueObject;
 
 use InvalidArgumentException;
-use Ramsey\Uuid\Uuid;
+use Symfony\Component\Uid\Uuid;
 
 final class UserId
 {
@@ -13,15 +13,16 @@ final class UserId
 
     private function __construct(string $value)
     {
-        if (empty($value)) {
+        if ($value === '') {
             throw new InvalidArgumentException('UserId cannot be empty.');
         }
+
         $this->value = $value;
     }
 
     public static function generate(): self
     {
-        return new self(Uuid::uuid4()->toString());
+        return new self(Uuid::v7()->toRfc4122());
     }
 
     public static function fromString(string $value): self

--- a/TaskManager/src/Infrastructure/GraphQL/Mutation/Task/CreateTaskMutation.php
+++ b/TaskManager/src/Infrastructure/GraphQL/Mutation/Task/CreateTaskMutation.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\GraphQL\Mutation\Task;
+
+use App\Application\Task\DTO\CreateTaskInput;
+use App\Application\Task\UseCase\CreateTaskUseCase;
+use Overblog\GraphQLBundle\Definition\Argument;
+
+final class CreateTaskMutation
+{
+    public function __construct(
+        private readonly CreateTaskUseCase $useCase,
+    ) {
+    }
+
+    public function __invoke(Argument $args): object
+    {
+        return $this->useCase->execute(new CreateTaskInput(
+            title: $args['title'],
+            description: $args['description'],
+            assignedUserId: $args['assignedUserId'],
+        ));
+    }
+}

--- a/TaskManager/src/Infrastructure/GraphQL/Mutation/Task/UpdateTaskStatusMutation.php
+++ b/TaskManager/src/Infrastructure/GraphQL/Mutation/Task/UpdateTaskStatusMutation.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\GraphQL\Mutation\Task;
+
+use App\Application\Task\UseCase\UpdateTaskStatusUseCase;
+use Overblog\GraphQLBundle\Definition\Argument;
+
+final class UpdateTaskStatusMutation
+{
+    public function __construct(
+        private readonly UpdateTaskStatusUseCase $useCase,
+    ) {
+    }
+
+    public function __invoke(Argument $args): object
+    {
+        return $this->useCase->execute(
+            taskId: $args['taskId'],
+            targetStatus: $args['status'],
+        );
+    }
+}

--- a/TaskManager/src/Infrastructure/GraphQL/Query/Task/AllTasksQuery.php
+++ b/TaskManager/src/Infrastructure/GraphQL/Query/Task/AllTasksQuery.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\GraphQL\Query\Task;
+
+use App\Domain\Task\Repository\TaskRepositoryInterface;
+use App\Infrastructure\Security\AuthorizationService;
+
+final class AllTasksQuery
+{
+    public function __construct(
+        private readonly TaskRepositoryInterface $taskRepository,
+        private readonly AuthorizationService $authorizationService,
+    ) {
+    }
+
+    public function __invoke(): array
+    {
+        $this->authorizationService->requireAdmin();
+
+        return $this->taskRepository->findAll();
+    }
+}

--- a/TaskManager/src/Infrastructure/GraphQL/Query/Task/MyTasksQuery.php
+++ b/TaskManager/src/Infrastructure/GraphQL/Query/Task/MyTasksQuery.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\GraphQL\Query\Task;
+
+use App\Domain\Task\Repository\TaskRepositoryInterface;
+use App\Domain\User\ValueObject\UserId;
+use App\Infrastructure\Security\AuthorizationService;
+
+final class MyTasksQuery
+{
+    public function __construct(
+        private readonly TaskRepositoryInterface $taskRepository,
+        private readonly AuthorizationService $authorizationService,
+    ) {
+    }
+
+    public function __invoke(): array
+    {
+        $user = $this->authorizationService->requireCurrentUser();
+
+        return $this->taskRepository->findByUser(
+            UserId::fromString($user->getId()->getValue())
+        );
+    }
+}

--- a/TaskManager/src/Infrastructure/GraphQL/Query/Task/TaskHistoryQuery.php
+++ b/TaskManager/src/Infrastructure/GraphQL/Query/Task/TaskHistoryQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\GraphQL\Query\Task;
+
+use App\Application\Task\UseCase\GetTaskHistoryUseCase;
+use Overblog\GraphQLBundle\Definition\Argument;
+
+final class TaskHistoryQuery
+{
+    public function __construct(
+        private readonly GetTaskHistoryUseCase $useCase,
+    ) {
+    }
+
+    public function __invoke(Argument $args): array
+    {
+        return $this->useCase->execute($args['taskId']);
+    }
+}

--- a/TaskManager/src/Infrastructure/Messenger/EventHandler/TaskCreatedEventHandler.php
+++ b/TaskManager/src/Infrastructure/Messenger/EventHandler/TaskCreatedEventHandler.php
@@ -11,17 +11,20 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 final class TaskCreatedEventHandler
 {
-    public function __construct(private readonly EventStoreRepository $eventStore) {}
+    public function __construct(
+        private readonly EventStoreRepository $eventStoreRepository,
+    ) {
+    }
 
     public function __invoke(TaskCreatedEvent $event): void
     {
-        $this->eventStore->append(
+        $this->eventStoreRepository->append(
             aggregateId: $event->taskId,
-            eventType:   TaskCreatedEvent::class,
-            payload:     [
-                'taskId'         => $event->taskId,
-                'title'          => $event->title,
-                'status'         => $event->status,
+            eventType: TaskCreatedEvent::class,
+            payload: [
+                'taskId' => $event->taskId,
+                'title' => $event->title,
+                'status' => $event->status,
                 'assignedUserId' => $event->assignedUserId,
             ],
             occurredAt: $event->occurredAt,

--- a/TaskManager/src/Infrastructure/Messenger/EventHandler/TaskStatusUpdatedEventHandler.php
+++ b/TaskManager/src/Infrastructure/Messenger/EventHandler/TaskStatusUpdatedEventHandler.php
@@ -11,17 +11,20 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 final class TaskStatusUpdatedEventHandler
 {
-    public function __construct(private readonly EventStoreRepository $eventStore) {}
+    public function __construct(
+        private readonly EventStoreRepository $eventStoreRepository,
+    ) {
+    }
 
     public function __invoke(TaskStatusUpdatedEvent $event): void
     {
-        $this->eventStore->append(
+        $this->eventStoreRepository->append(
             aggregateId: $event->taskId,
-            eventType:   TaskStatusUpdatedEvent::class,
-            payload:     [
-                'taskId'         => $event->taskId,
+            eventType: TaskStatusUpdatedEvent::class,
+            payload: [
+                'taskId' => $event->taskId,
                 'previousStatus' => $event->previousStatus,
-                'newStatus'      => $event->newStatus,
+                'newStatus' => $event->newStatus,
             ],
             occurredAt: $event->occurredAt,
         );

--- a/TaskManager/src/Infrastructure/Security/AuthorizationService.php
+++ b/TaskManager/src/Infrastructure/Security/AuthorizationService.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Security;
+
+use App\Domain\User\Entity\User;
+use App\Domain\User\Repository\UserRepositoryInterface;
+use App\Domain\User\ValueObject\UserId;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class AuthorizationService
+{
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly TokenService $tokenService,
+        private readonly UserRepositoryInterface $userRepository,
+    ) {
+    }
+
+    public function getCurrentUser(): ?User
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if ($request === null) {
+            return null;
+        }
+
+        $authorization = $request->headers->get('Authorization');
+
+        if (!$authorization || !str_starts_with($authorization, 'Bearer ')) {
+            return null;
+        }
+
+        $token = substr($authorization, 7);
+        $userId = $this->tokenService->extractUserId($token);
+
+        if ($userId === null) {
+            return null;
+        }
+
+        return $this->userRepository->findById(UserId::fromString($userId));
+    }
+
+    public function requireCurrentUser(): User
+    {
+        $user = $this->getCurrentUser();
+
+        if ($user === null) {
+            throw new RuntimeException('Unauthorized.');
+        }
+
+        return $user;
+    }
+
+    public function requireAdmin(): User
+    {
+        $user = $this->requireCurrentUser();
+
+        if (!$user->isAdmin()) {
+            throw new RuntimeException('Forbidden. Admin access required.');
+        }
+
+        return $user;
+    }
+
+    public function canAccessUserTasks(string $userId): bool
+    {
+        $currentUser = $this->getCurrentUser();
+
+        if ($currentUser === null) {
+            return false;
+        }
+
+        return $currentUser->isAdmin() || $currentUser->getId()->getValue() === $userId;
+    }
+
+    public function canManageTaskAssignedTo(string $assignedUserId): bool
+    {
+        $currentUser = $this->getCurrentUser();
+
+        if ($currentUser === null) {
+            return false;
+        }
+
+        return $currentUser->isAdmin() || $currentUser->getId()->getValue() === $assignedUserId;
+    }
+}

--- a/TaskManager/symfony.lock
+++ b/TaskManager/symfony.lock
@@ -279,6 +279,15 @@
             "templates/base.html.twig"
         ]
     },
+    "symfony/uid": {
+        "version": "7.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "7.0",
+            "ref": "0df5844274d871b37fc3816c57a768ffc60a43a5"
+        }
+    },
     "symfony/ux-turbo": {
         "version": "2.32",
         "recipe": {


### PR DESCRIPTION
Add task creation and task status update use cases with GraphQL mutations. Add GraphQL queries for admin tasks, current user tasks and task history. Introduce AuthorizationService facade built on top of TokenService for token-based access control. Update task GraphQL types and task status strategy wiring. Switch task and user identifiers to Symfony UID.

Refs: #12
Refs: #13
Refs: #14
Refs: #15
Refs: #16
Refs: #17
Refs: #18
Refs: #19
Refs: #23