### PR TITLE
#20, #21, #22 feat(tasks): dispatch task domain events asynchronously via messenger…

### DIFF
--- a/TaskManager/config/packages/messenger.yaml
+++ b/TaskManager/config/packages/messenger.yaml
@@ -3,14 +3,15 @@ framework:
         failure_transport: failed
 
         transports:
-            # https://symfony.com/doc/current/messenger.html#transport-configuration
+            # Use the DSN from .env / .env.local, for example:
+            # MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
             async:
                 dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
                 retry_strategy:
                     max_retries: 3
                     multiplier: 2
+
             failed: 'doctrine://default?queue_name=failed'
-            # sync: 'sync://'
 
         default_bus: messenger.bus.default
 
@@ -22,5 +23,5 @@ framework:
             Symfony\Component\Notifier\Message\ChatMessage: async
             Symfony\Component\Notifier\Message\SmsMessage: async
 
-            # Route your messages to the transports
-            # 'App\Message\YourMessage': async
+            App\Domain\Task\Event\TaskCreatedEvent: async
+            App\Domain\Task\Event\TaskStatusUpdatedEvent: async

--- a/TaskManager/config/services.yaml
+++ b/TaskManager/config/services.yaml
@@ -102,3 +102,10 @@ services:
         public: true
         autowire: true
         autoconfigure: true
+
+    App\Domain\Shared\Event\DomainEventDispatcherInterface:
+        class: App\Infrastructure\Messenger\SymfonyMessengerDomainEventDispatcher
+
+    App\Infrastructure\Messenger\SymfonyMessengerDomainEventDispatcher:
+        autowire: true
+        autoconfigure: true

--- a/TaskManager/src/Application/Task/DTO/CreateTaskInput.php
+++ b/TaskManager/src/Application/Task/DTO/CreateTaskInput.php
@@ -10,5 +10,6 @@ final class CreateTaskInput
         public readonly string $title,
         public readonly string $description,
         public readonly string $assignedUserId,
-    ) {}
+    ) {
+    }
 }

--- a/TaskManager/src/Application/Task/Factory/TaskFactory.php
+++ b/TaskManager/src/Application/Task/Factory/TaskFactory.php
@@ -28,12 +28,12 @@ final class TaskFactory
         }
 
         return new Task(
-            id:             TaskId::generate(),
-            title:          trim($title),
-            description:    trim($description),
-            status:         TaskStatus::fromString($status),
+            id: TaskId::generate(),
+            title: trim($title),
+            description: trim($description),
+            status: TaskStatus::fromString($status),
             assignedUserId: UserId::fromString($assignedUserId),
-            createdAt:      new DateTimeImmutable(),
+            createdAt: new DateTimeImmutable(),
         );
     }
 
@@ -46,12 +46,12 @@ final class TaskFactory
         DateTimeImmutable $createdAt,
     ): Task {
         return new Task(
-            id:             TaskId::fromString($id),
-            title:          $title,
-            description:    $description,
-            status:         TaskStatus::fromString($status),
+            id: TaskId::fromString($id),
+            title: $title,
+            description: $description,
+            status: TaskStatus::fromString($status),
             assignedUserId: UserId::fromString($assignedUserId),
-            createdAt:      $createdAt,
+            createdAt: $createdAt,
         );
     }
 }

--- a/TaskManager/src/Application/Task/Strategy/MoveToDoneStrategy.php
+++ b/TaskManager/src/Application/Task/Strategy/MoveToDoneStrategy.php
@@ -9,9 +9,6 @@ use App\Domain\Task\Strategy\TaskStatusStrategyInterface;
 use App\Domain\Task\ValueObject\TaskStatus;
 use DomainException;
 
-/**
- * Strategy Pattern — transitions a task from "in_progress" to "done".
- */
 final class MoveToDoneStrategy implements TaskStatusStrategyInterface
 {
     public function supports(TaskStatus $currentStatus): bool

--- a/TaskManager/src/Application/Task/Strategy/TaskStatusContext.php
+++ b/TaskManager/src/Application/Task/Strategy/TaskStatusContext.php
@@ -12,7 +12,9 @@ use DomainException;
 final class TaskStatusContext
 {
     /** @param iterable<TaskStatusStrategyInterface> $strategies */
-    public function __construct(private readonly iterable $strategies) {}
+    public function __construct(private readonly iterable $strategies)
+    {
+    }
 
     public function transition(Task $task, TaskStatus $targetStatus): void
     {

--- a/TaskManager/src/Application/Task/UseCase/CreateTaskUseCase.php
+++ b/TaskManager/src/Application/Task/UseCase/CreateTaskUseCase.php
@@ -6,6 +6,7 @@ namespace App\Application\Task\UseCase;
 
 use App\Application\Task\DTO\CreateTaskInput;
 use App\Application\Task\Factory\TaskFactory;
+use App\Domain\Shared\Event\DomainEventDispatcherInterface;
 use App\Domain\Task\Entity\Task;
 use App\Domain\Task\Repository\TaskRepositoryInterface;
 use App\Infrastructure\Security\AuthorizationService;
@@ -16,6 +17,7 @@ final class CreateTaskUseCase
         private readonly TaskFactory $taskFactory,
         private readonly TaskRepositoryInterface $taskRepository,
         private readonly AuthorizationService $authorizationService,
+        private readonly DomainEventDispatcherInterface $domainEventDispatcher,
     ) {
     }
 
@@ -29,7 +31,10 @@ final class CreateTaskUseCase
             assignedUserId: $input->assignedUserId,
         );
 
+        $events = $task->pullDomainEvents();
+
         $this->taskRepository->save($task);
+        $this->domainEventDispatcher->dispatchAll($events);
 
         return $task;
     }

--- a/TaskManager/src/Application/Task/UseCase/UpdateTaskStatusUseCase.php
+++ b/TaskManager/src/Application/Task/UseCase/UpdateTaskStatusUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Application\Task\UseCase;
 
 use App\Application\Task\Strategy\TaskStatusContext;
+use App\Domain\Shared\Event\DomainEventDispatcherInterface;
 use App\Domain\Task\Entity\Task;
 use App\Domain\Task\Repository\TaskRepositoryInterface;
 use App\Domain\Task\ValueObject\TaskId;
@@ -18,6 +19,7 @@ final class UpdateTaskStatusUseCase
         private readonly TaskRepositoryInterface $taskRepository,
         private readonly TaskStatusContext $taskStatusContext,
         private readonly AuthorizationService $authorizationService,
+        private readonly DomainEventDispatcherInterface $domainEventDispatcher,
     ) {
     }
 
@@ -34,7 +36,11 @@ final class UpdateTaskStatusUseCase
         }
 
         $this->taskStatusContext->transition($task, TaskStatus::fromString($targetStatus));
+
+        $events = $task->pullDomainEvents();
+
         $this->taskRepository->save($task);
+        $this->domainEventDispatcher->dispatchAll($events);
 
         return $task;
     }

--- a/TaskManager/src/Application/Task/UseCase/UpdateTaskStatusUseCase.php
+++ b/TaskManager/src/Application/Task/UseCase/UpdateTaskStatusUseCase.php
@@ -37,10 +37,20 @@ final class UpdateTaskStatusUseCase
 
         $this->taskStatusContext->transition($task, TaskStatus::fromString($targetStatus));
 
+        $this->taskRepository->save($task);
+
         $events = $task->pullDomainEvents();
 
-        $this->taskRepository->save($task);
-        $this->domainEventDispatcher->dispatchAll($events);
+        try {
+            $this->domainEventDispatcher->dispatchAll($events);
+        } catch (\Throwable $exception) {
+            // Events dispatch failure should not invalidate the already-persisted task update.
+            error_log(sprintf(
+                'Failed to dispatch domain events for task "%s": %s',
+                $taskId,
+                $exception->getMessage()
+            ));
+        }
 
         return $task;
     }

--- a/TaskManager/src/Application/User/UseCase/ImportUsersFromJSONPlaceholderUseCase.php
+++ b/TaskManager/src/Application/User/UseCase/ImportUsersFromJSONPlaceholderUseCase.php
@@ -14,7 +14,8 @@ final class ImportUsersFromJSONPlaceholderUseCase
     public function __construct(
         private readonly JSONPlaceholderClient $client,
         private readonly UserRepositoryInterface $repository,
-    ) {}
+    ) {
+    }
 
     public function execute(): array
     {

--- a/TaskManager/src/Application/User/UseCase/LoginUserUseCase.php
+++ b/TaskManager/src/Application/User/UseCase/LoginUserUseCase.php
@@ -10,7 +10,8 @@ final class LoginUserUseCase
 {
     public function __construct(
         private readonly UserRepositoryInterface $repository,
-    ) {}
+    ) {
+    }
 
     public function execute(string $username): User
     {

--- a/TaskManager/src/Domain/Shared/Event/DomainEventDispatcherInterface.php
+++ b/TaskManager/src/Domain/Shared/Event/DomainEventDispatcherInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Shared\Event;
+
+interface DomainEventDispatcherInterface
+{
+    /** @param object[] $events */
+    public function dispatchAll(array $events): void;
+}

--- a/TaskManager/src/Domain/Task/Entity/Task.php
+++ b/TaskManager/src/Domain/Task/Entity/Task.php
@@ -13,11 +13,11 @@ use DateTimeImmutable;
 
 class Task
 {
-    private TaskId            $id;
-    private string            $title;
-    private string            $description;
-    private TaskStatus        $status;
-    private UserId            $assignedUserId;
+    private TaskId $id;
+    private string $title;
+    private string $description;
+    private TaskStatus $status;
+    private UserId $assignedUserId;
     private DateTimeImmutable $createdAt;
     private DateTimeImmutable $updatedAt;
 
@@ -25,20 +25,20 @@ class Task
     private array $domainEvents = [];
 
     public function __construct(
-        TaskId            $id,
-        string            $title,
-        string            $description,
-        TaskStatus        $status,
-        UserId            $assignedUserId,
+        TaskId $id,
+        string $title,
+        string $description,
+        TaskStatus $status,
+        UserId $assignedUserId,
         DateTimeImmutable $createdAt,
     ) {
-        $this->id             = $id;
-        $this->title          = $title;
-        $this->description    = $description;
-        $this->status         = $status;
+        $this->id = $id;
+        $this->title = $title;
+        $this->description = $description;
+        $this->status = $status;
         $this->assignedUserId = $assignedUserId;
-        $this->createdAt      = $createdAt;
-        $this->updatedAt      = $createdAt;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $createdAt;
 
         $this->recordEvent(new TaskCreatedEvent(
             $id->getValue(),
@@ -51,8 +51,8 @@ class Task
 
     public function changeStatus(TaskStatus $newStatus): void
     {
-        $previous      = $this->status->getValue();
-        $this->status  = $newStatus;
+        $previous = $this->status->getValue();
+        $this->status = $newStatus;
         $this->updatedAt = new DateTimeImmutable();
 
         $this->recordEvent(new TaskStatusUpdatedEvent(
@@ -101,7 +101,7 @@ class Task
     /** @return object[] */
     public function pullDomainEvents(): array
     {
-        $events             = $this->domainEvents;
+        $events = $this->domainEvents;
         $this->domainEvents = [];
 
         return $events;

--- a/TaskManager/src/Domain/Task/ValueObject/TaskStatus.php
+++ b/TaskManager/src/Domain/Task/ValueObject/TaskStatus.php
@@ -8,9 +8,9 @@ use InvalidArgumentException;
 
 final class TaskStatus
 {
-    public const TODO        = 'todo';
+    public const TODO = 'todo';
     public const IN_PROGRESS = 'in_progress';
-    public const DONE        = 'done';
+    public const DONE = 'done';
 
     private const VALID = [self::TODO, self::IN_PROGRESS, self::DONE];
 

--- a/TaskManager/src/Infrastructure/External/JSONPlaceholder/JSONPlaceholderClient.php
+++ b/TaskManager/src/Infrastructure/External/JSONPlaceholder/JSONPlaceholderClient.php
@@ -11,7 +11,9 @@ final class JSONPlaceholderClient
 {
     private const BASE_URL = 'https://jsonplaceholder.typicode.com';
 
-    public function __construct(private readonly HttpClientInterface $httpClient) {}
+    public function __construct(private readonly HttpClientInterface $httpClient)
+    {
+    }
 
     /**
      * Fetches all users from JSONPlaceholder.

--- a/TaskManager/src/Infrastructure/Messenger/SymfonyMessengerDomainEventDispatcher.php
+++ b/TaskManager/src/Infrastructure/Messenger/SymfonyMessengerDomainEventDispatcher.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Messenger;
+
+use App\Domain\Shared\Event\DomainEventDispatcherInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class SymfonyMessengerDomainEventDispatcher implements DomainEventDispatcherInterface
+{
+    public function __construct(
+        private readonly MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function dispatchAll(array $events): void
+    {
+        foreach ($events as $event) {
+            $this->messageBus->dispatch($event);
+        }
+    }
+}

--- a/TaskManager/src/Infrastructure/Persistence/Doctrine/EventStore/EventStoreRepository.php
+++ b/TaskManager/src/Infrastructure/Persistence/Doctrine/EventStore/EventStoreRepository.php
@@ -9,19 +9,21 @@ use Doctrine\ORM\EntityManagerInterface;
 
 final class EventStoreRepository
 {
-    public function __construct(private readonly EntityManagerInterface $em) {}
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+    }
 
     public function append(
-        string            $aggregateId,
-        string            $eventType,
-        array             $payload,
+        string $aggregateId,
+        string $eventType,
+        array $payload,
         DateTimeImmutable $occurredAt,
     ): void {
         $event = new StoredEvent(
             aggregateId: $aggregateId,
-            eventType:   $eventType,
-            payload:     $payload,
-            occurredAt:  $occurredAt,
+            eventType: $eventType,
+            payload: $payload,
+            occurredAt: $occurredAt,
         );
 
         $this->em->persist($event);

--- a/TaskManager/src/Infrastructure/Persistence/Doctrine/Task/DoctrineTaskRepository.php
+++ b/TaskManager/src/Infrastructure/Persistence/Doctrine/Task/DoctrineTaskRepository.php
@@ -15,8 +15,9 @@ final class DoctrineTaskRepository implements TaskRepositoryInterface
 {
     public function __construct(
         private readonly EntityManagerInterface $em,
-        private readonly TaskFactory            $factory,
-    ) {}
+        private readonly TaskFactory $factory,
+    ) {
+    }
 
     public function save(Task $task): void
     {

--- a/TaskManager/src/Infrastructure/Persistence/Doctrine/User/DoctrineUserRepository.php
+++ b/TaskManager/src/Infrastructure/Persistence/Doctrine/User/DoctrineUserRepository.php
@@ -11,7 +11,9 @@ use Doctrine\ORM\EntityManagerInterface;
 
 final class DoctrineUserRepository implements UserRepositoryInterface
 {
-    public function __construct(private readonly EntityManagerInterface $em) {}
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+    }
 
     public function save(User $user): void
     {

--- a/TaskManager/src/Infrastructure/Security/TokenService.php
+++ b/TaskManager/src/Infrastructure/Security/TokenService.php
@@ -20,7 +20,7 @@ final class TokenService
 
         $signature = hash_hmac('sha256', $payload, $this->appSecret);
 
-        return $payload.'.'.$signature;
+        return $payload . '.' . $signature;
     }
 
     public function extractUserId(string $token): ?string


### PR DESCRIPTION
… and event store

Add a domain event dispatcher abstraction and Symfony Messenger adapter. Dispatch task created and task status updated events through the async transport. Update task use cases to publish domain events via the dispatcher service. Wire messenger and services configuration for asynchronous task event processing.

Closes #20
Closes #21
Closes #22