### PR TITLE
fix(docker): restore writable Symfony cache in production containers

### DIFF
--- a/docker/php/Dockerfile.prod
+++ b/docker/php/Dockerfile.prod
@@ -25,6 +25,7 @@ COPY docker/php/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY docker/php/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 RUN chmod +x /usr/local/bin/entrypoint.sh \
+    && mkdir -p /var/www/app/var/cache /var/www/app/var/log /var/www/app/var/sessions \
     && composer install --no-dev --optimize-autoloader --no-interaction \
     && php bin/console cache:clear --env=prod || true
 

--- a/docker/php/entrypoint.sh
+++ b/docker/php/entrypoint.sh
@@ -11,11 +11,17 @@ if [ -f composer.json ] && [ ! -d vendor ]; then
   composer install --no-interaction --prefer-dist
 fi
 
-mkdir -p var/cache var/log
-chmod -R 777 var || true
+mkdir -p var/cache var/log var/sessions
+
+chown -R www-data:www-data var || true
+chmod -R 775 var || true
 
 php bin/console doctrine:database:create --if-not-exists --no-interaction || true
-php bin/console doctrine:migrations:diff --no-interaction --allow-empty-diff || true
+
+if [ "${APP_ENV:-dev}" = "dev" ]; then
+  php bin/console doctrine:migrations:diff --no-interaction --allow-empty-diff || true
+fi
+
 php bin/console doctrine:migrations:migrate --no-interaction || true
 php bin/console messenger:setup-transports --no-interaction || true
 

--- a/infrastructure.yml
+++ b/infrastructure.yml
@@ -103,6 +103,8 @@ services:
       MESSENGER_TRANSPORT_DSN: "doctrine://default?auto_setup=0"
     ports:
       - "${APP_PORT_PROD:-19001}:9000"
+    volumes:
+      - app_var_prod:/var/www/app/var
     depends_on:
       postgres:
         condition: service_healthy
@@ -130,6 +132,7 @@ volumes:
   postgres_data:
   pgadmin_data:
   app_var:
+  app_var_prod:
 
 networks:
   task_manager_net:


### PR DESCRIPTION
Ensure the production app container can write Symfony cache and log files after Docker volumes are mounted. Update the entrypoint to prepare the var directory at runtime, adjust the production image setup, and align the production compose configuration with writable application storage.

Refs: #26
Refs: #41